### PR TITLE
wasihttp: implement RoundTrip for wasihttp.Transport

### DIFF
--- a/examples/roundtrip/roundtrip.go
+++ b/examples/roundtrip/roundtrip.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	wasihttp "github.com/ydnar/wasi-http-go/wasihttp"
+)
+
+func printResponse(r *http.Response) {
+	fmt.Printf("Status: %d\n", r.StatusCode)
+	for k, v := range r.Header {
+		fmt.Printf("%s: %s\n", k, v[0])
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("Body: \n%s\n", body)
+}
+
+func main() {
+	client := &http.Client{
+		Transport: &wasihttp.Transport{},
+	}
+	req, err := http.NewRequest("GET", "https://postman-echo.com/get", nil)
+	if err != nil {
+		panic(err.Error())
+	}
+	if req == nil {
+		panic("Nil request!")
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		panic(err.Error())
+	}
+	defer res.Body.Close()
+	printResponse(res)
+
+	res, err = client.Post("https://postman-echo.com/post", "application/json", bytes.NewReader([]byte("{\"foo\": \"bar\"}")))
+	if err != nil {
+		panic(err.Error())
+	}
+	defer res.Body.Close()
+	printResponse(res)
+
+	req, err = http.NewRequest("PUT", "http://postman-echo.com/put", bytes.NewReader([]byte("{\"baz\": \"blah\"}")))
+	if err != nil {
+		panic(err.Error())
+	}
+	if req == nil {
+		panic("Nil request!")
+	}
+	res, err = client.Do(req)
+	if err != nil {
+		panic(err.Error())
+	}
+	defer res.Body.Close()
+	printResponse(res)
+}

--- a/wasihttp/transport.go
+++ b/wasihttp/transport.go
@@ -1,6 +1,13 @@
 package wasihttp
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/bytecodealliance/wasm-tools-go/cm"
+	outgoinghandler "github.com/ydnar/wasi-http-go/internal/wasi/http/outgoing-handler"
+	"github.com/ydnar/wasi-http-go/internal/wasi/http/types"
+)
 
 var _ http.RoundTripper = &Transport{}
 
@@ -11,5 +18,83 @@ type Transport struct{}
 //
 // [wasi-http]: https://github.com/webassembly/wasi-http
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return nil, nil
+	hdrs := ToHeaders(req.Header)
+
+	outgoingRequest := types.NewOutgoingRequest(hdrs)
+
+	auth := Authority(req)
+	// TODO: when should we set the authority to `cm.None`?
+	outgoingRequest.SetAuthority(cm.Some(auth))
+
+	m := ToMethod(req.Method)
+	outgoingRequest.SetMethod(m)
+
+	p := ToPathWithQuery(req)
+	outgoingRequest.SetPathWithQuery(p)
+
+	scheme := ToScheme(req.URL.Scheme)
+	outgoingRequest.SetScheme(cm.Some(scheme))
+
+	outgoingBody_ := outgoingRequest.Body()
+	outgoingBody := outgoingBody_.OK() // the first call should always return OK
+
+	// TODO: when are [options] used?
+	// [options]: https://github.com/WebAssembly/wasi-http/blob/main/wit/handler.wit#L38-L39
+	futureIncomingResponse_ := outgoinghandler.Handle(outgoingRequest, cm.None[types.RequestOptions]())
+
+	if err := checkError(futureIncomingResponse_); err != nil {
+		// outgoing request is invalid or not allowed to be made
+		return nil, err
+	}
+
+	ToBody(&req.Body, outgoingBody)
+
+	// Finalize the request body
+	// TODO: complete the request trailers
+	finish := types.OutgoingBodyFinish(*outgoingBody, cm.None[types.Fields]())
+	if err := checkError(finish); err != nil {
+		return nil, err
+	}
+
+	futureIncomingResponse := futureIncomingResponse_.OK()
+	defer futureIncomingResponse.ResourceDrop()
+	poll := futureIncomingResponse.Subscribe()
+	defer poll.ResourceDrop()
+	if !poll.Ready() {
+		poll.Block()
+	}
+	responseBody := futureIncomingResponse.Get()
+	if responseBody.None() {
+		return nil, fmt.Errorf("wasihttp: response is None after blocking")
+	}
+
+	incomingResponse_ := responseBody.Some().OK() // the first call should always return OK
+	if err := checkError(*incomingResponse_); err != nil {
+		// TODO: what do we do with the HTTP proxy error-code?
+		return nil, err
+	}
+	incomingResponse := incomingResponse_.OK()
+	defer incomingResponse.ResourceDrop()
+
+	response := &http.Response{
+		Status:     http.StatusText(int(incomingResponse.Status())),
+		StatusCode: int(incomingResponse.Status()),
+		Header:     FromHeaders(incomingResponse.Headers()),
+	}
+
+	ib := incomingResponse.Consume()
+	if err := checkError(ib); err != nil {
+		return nil, err
+	}
+	incomingBody := ib.OK()
+
+	response.Body = FromBody(incomingBody)
+	return response, nil
+}
+
+func checkError[Shape, Ok, Err any](result cm.Result[Shape, Ok, Err]) error {
+	if result.IsErr() {
+		return fmt.Errorf("wasihttp: %v", result.Err())
+	}
+	return nil
 }

--- a/wasihttp/types.go
+++ b/wasihttp/types.go
@@ -1,0 +1,187 @@
+package wasihttp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/bytecodealliance/wasm-tools-go/cm"
+	"github.com/ydnar/wasi-http-go/internal/wasi/http/types"
+	"github.com/ydnar/wasi-http-go/internal/wasi/io/streams"
+)
+
+// Authority returns the Authority of the request from the [http.Request] Host or URL.Host.
+//
+// [http.Request]: https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/net/http/request.go;l=240-243
+func Authority(req *http.Request) string {
+	auth := ""
+	if req.Host == "" {
+		auth = req.URL.Host
+	} else {
+		auth = req.Host
+	}
+	return auth
+}
+
+// ToHeaders convert the [http.Header] to a wasi-http [types.Fields].
+//
+// [http.Header]: https://pkg.go.dev/net/http#Header
+// [types.Fields]: https://github.com/WebAssembly/wasi-http/blob/v0.2.0/wit/types.wit#L215
+func ToHeaders(headers http.Header) (fields types.Fields) {
+	fields = types.NewFields()
+	for k, v := range headers {
+		key := types.FieldKey(k)
+		vals := []types.FieldValue{}
+		for _, vv := range v {
+			vals = append(vals, types.FieldValue(cm.ToList([]uint8(vv))))
+		}
+		fields.Set(key, cm.ToList(vals))
+	}
+	return
+}
+
+// FromHeaders convert the wasi-http [types.Fields] to a [http.Header].
+//
+// [http.Header]: https://pkg.go.dev/net/http#Header
+// [types.Fields]: https://github.com/WebAssembly/wasi-http/blob/v0.2.0/wit/types.wit#L215
+func FromHeaders(fields types.Fields) http.Header {
+	h := http.Header{}
+	es := fields.Entries()
+	for _, field := range es.Slice() {
+		k, v := string(field.F0), string(field.F1.Slice())
+		h.Add(k, v)
+	}
+	fields.ResourceDrop()
+	return h
+}
+
+// ToMethod returns the wasi-http [types.ToMethod] from the [http.Request] method.
+// If the method is not a standard HTTP method, it returns a [types.MethodOther].
+//
+// [http.Request]: https://pkg.go.dev/net/http#Request
+// [types.ToMethod]: https://github.com/WebAssembly/wasi-http/blob/v0.2.0/wit/types.wit#L11-L22
+func ToMethod(s string) types.Method {
+	switch s {
+	case http.MethodGet:
+		return types.MethodGet()
+	case http.MethodHead:
+		return types.MethodHead()
+	case http.MethodPost:
+		return types.MethodPost()
+	case http.MethodPut:
+		return types.MethodPut()
+	case http.MethodPatch:
+		return types.MethodPatch()
+	case http.MethodDelete:
+		return types.MethodDelete()
+	case http.MethodConnect:
+		return types.MethodConnect()
+	case http.MethodOptions:
+		return types.MethodOptions()
+	case http.MethodTrace:
+		return types.MethodTrace()
+	default:
+		// TODO: is other method allowed? or should we return GET?
+		// https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/net/http/method.go
+		// https://github.com/WebAssembly/wasi-http/blob/main/wit/types.wit#L340C41-L341C69
+		return types.MethodOther(s)
+	}
+}
+
+// ToPathWithQuery returns the path with query from the [http.Request] URL.
+//
+// if both path and query are empty, set it to None
+// [http.Request]: https://pkg.go.dev/net/http#Request
+// [types.ToPathWithQuery]: https://github.com/WebAssembly/wasi-http/blob/main/wit/types.wit#L350
+func ToPathWithQuery(req *http.Request) cm.Option[string] {
+	path_with_query := req.URL.RequestURI()
+	if path_with_query == "" {
+		return cm.None[string]()
+	}
+	return cm.Some(path_with_query)
+}
+
+// ToScheme returns the wasi-http [types.ToScheme] from the [http.Request] URL.ToScheme.
+// If the scheme is not http or https, it returns a [types.SchemeOther].
+//
+// [http.Request]: https://pkg.go.dev/net/http#Request
+// [types.ToScheme]: https://github.com/WebAssembly/wasi-http/blob/main/wit/types.wit#L359-L360
+func ToScheme(s string) types.Scheme {
+	switch s {
+	case "http":
+		return types.SchemeHTTP()
+	case "https":
+		return types.SchemeHTTPS()
+	default:
+		// TODO: when should we set the scheme to `cm.None` if `req.URL.Scheme` is empty?
+		return types.SchemeOther(s)
+	}
+}
+
+// ToBody writes the io.ReadCloser to the wasi-http [types.ToBody].
+//
+// [types.ToBody]: https://github.com/WebAssembly/wasi-http/blob/v0.2.0/wit/types.wit#L514-L540
+func ToBody(body *io.ReadCloser, wasiBody *types.OutgoingBody) error {
+	if body == nil || *body == nil {
+		return nil
+	}
+	defer (*body).Close()
+
+	stream_ := wasiBody.Write()
+	stream := stream_.OK() // the first call should always return OK
+	defer stream.ResourceDrop()
+	if _, err := io.Copy(&outStreamWriter{stream: stream}, *body); err != nil {
+		return fmt.Errorf("wasihttp: %v", err)
+	}
+	return nil
+}
+
+// FromBody reads the wasi-http [types.IncomingBody] to the io.ReadCloser.
+//
+// [types.IncomingBody]: https://github.com/WebAssembly/wasi-http/blob/v0.2.0/wit/types.wit#L397-L427
+func FromBody(body *types.IncomingBody) io.ReadCloser {
+	stream_ := body.Stream()
+	stream := stream_.OK() // the first call should always return OK
+	return &inputStreamReader{stream: stream, incomingBody: body}
+}
+
+type outStreamWriter struct {
+	stream *streams.OutputStream
+}
+
+func (s *outStreamWriter) Write(p []byte) (n int, err error) {
+	res := s.stream.BlockingWriteAndFlush(cm.ToList(p))
+	if res.IsErr() {
+		return 0, fmt.Errorf("wasihttp: %v", res.Err())
+	}
+	return len(p), nil
+}
+
+type inputStreamReader struct {
+	stream       *streams.InputStream
+	incomingBody *types.IncomingBody
+}
+
+func (r *inputStreamReader) Read(p []byte) (n int, err error) {
+	poll := r.stream.Subscribe()
+	poll.Block()
+	poll.ResourceDrop()
+
+	readResult := r.stream.Read(uint64(len(p)))
+	if err := readResult.Err(); err != nil {
+		if err.Closed() {
+			return 0, io.EOF
+		}
+		return 0, fmt.Errorf("failed to read from InputStream %s", err.LastOperationFailed().ToDebugString())
+	}
+
+	readList := *readResult.OK()
+	copy(p, readList.Slice())
+	return int(readList.Len()), nil
+}
+
+func (r *inputStreamReader) Close() error {
+	r.stream.ResourceDrop()
+	r.incomingBody.ResourceDrop()
+	return nil
+}


### PR DESCRIPTION
This commit adds a RoundTrip method to wasihttp.Transport, which is required to implement the http.RoundTripper interface. This method is used to execute a single HTTP request and return the response.