### PR TITLE
wasihttp, examples: reverse proxy example

### DIFF
--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -21,7 +21,7 @@ func init() {
 
 	http.HandleFunc("/counter", func(w http.ResponseWriter, r *http.Request) {
 		n := <-c
-		w.Write([]byte(fmt.Sprintf("%d", n)))
+		fmt.Fprintf(w, "%d", n)
 	})
 
 	go func() {

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -1,3 +1,10 @@
+// This example implements a basic web server.
+//
+// To run: `tinygo run -target=wasip2-http.json ./examples/basic`
+// Test /: `curl -v 'http://0.0.0.0:8080/'`
+// Test /safe: `curl -v 'http://0.0.0.0:8080/safe'`
+// Test /counter: `curl -v 'http://0.0.0.0:8080/counter'`
+
 package main
 
 import (

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -26,6 +26,10 @@ func init() {
 		w.Write([]byte("Welcome to /safe\n"))
 	})
 
+	http.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		// do nothing, force default response handling
+	})
+
 	http.HandleFunc("/counter", func(w http.ResponseWriter, r *http.Request) {
 		n := <-c
 		fmt.Fprintf(w, "%d", n)

--- a/examples/proxy/proxy.go
+++ b/examples/proxy/proxy.go
@@ -1,0 +1,62 @@
+// This example implements a reverse proxy that sends requests to postman-echo.com.
+//
+// To run: `tinygo run -target=wasip2-http.json ./examples/proxy`
+// Test GET: `curl -v 'http://0.0.0.0:8080/get'`
+// Test POST: `curl -v -d hello 'http://0.0.0.0:8080/post'`
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/ydnar/wasi-http-go/wasihttp"
+)
+
+func init() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		r2 := r.Clone(ctx)
+		r2.Host = "postman-echo.com"
+		r2.URL.Host = "postman-echo.com"
+		r2.URL.Scheme = "https"
+
+		defer func() {
+			dur := time.Since(start)
+			log.Printf("proxied %s in %s\n", r2.URL.String(), dur.String())
+		}()
+
+		client := &http.Client{
+			Transport: &wasihttp.Transport{},
+		}
+		res, err := client.Do(r2)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "error: %v", err)
+			log.Printf("error: %v", err)
+			return
+		}
+
+		for k, v := range res.Header {
+			for _, vv := range v {
+				w.Header().Add(k, vv)
+			}
+		}
+
+		w.WriteHeader(res.StatusCode)
+		if res.Body != nil {
+			io.Copy(w, res.Body)
+			res.Body.Close()
+		}
+	})
+}
+
+func main() {}

--- a/examples/proxy/proxy.go
+++ b/examples/proxy/proxy.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ydnar/wasi-http-go/wasihttp"
+	_ "github.com/ydnar/wasi-http-go/wasihttp"
 )
 
 func init() {
@@ -34,10 +34,7 @@ func init() {
 			log.Printf("proxied %s in %s\n", r2.URL.String(), dur.String())
 		}()
 
-		client := &http.Client{
-			Transport: &wasihttp.Transport{},
-		}
-		res, err := client.Do(r2)
+		res, err := http.DefaultClient.Do(r2)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "error: %v", err)

--- a/wasihttp/server.go
+++ b/wasihttp/server.go
@@ -108,14 +108,16 @@ func (w *responseWriter) finish() error {
 		return nil
 	}
 	if !w.wroteHeader {
-		w.WriteHeader(http.StatusOK)
+		// w.WriteHeader(http.StatusOK)
+		// If caller code did not set headers, status, or body, then respond with an error
+		// and let the server implementation handle the correct response.
+		w.fatal(types.ErrorCodeHTTPResponseIncomplete())
+		return nil
 	}
 
 	w.finished = true
 	return w.writer.finish()
 }
-
-type outgoingResult = cm.Result[types.ErrorCodeShape, types.OutgoingResponse, types.ErrorCode]
 
 // fatal sets an error code on the response, to allow the implementation
 // to determine how to respond with an HTTP error response.
@@ -123,3 +125,5 @@ func (w *responseWriter) fatal(e types.ErrorCode) {
 	w.finished = true
 	types.ResponseOutparamSet(w.out, cm.Err[outgoingResult](e))
 }
+
+type outgoingResult = cm.Result[types.ErrorCodeShape, types.OutgoingResponse, types.ErrorCode]

--- a/wasihttp/transport.go
+++ b/wasihttp/transport.go
@@ -11,7 +11,13 @@ import (
 	"github.com/ydnar/wasi-http-go/internal/wasi/http/types"
 )
 
-var _ http.RoundTripper = &Transport{}
+func init() {
+	// Override the default net/http transport and client.
+	http.DefaultTransport = &Transport{}
+	if http.DefaultClient != nil {
+		http.DefaultClient.Transport = &Transport{} // TinyGo has custom implementation of net/http
+	}
+}
 
 type Transport struct{}
 

--- a/wasihttp/types.go
+++ b/wasihttp/types.go
@@ -131,7 +131,9 @@ func (r *bodyReader) finish() error {
 		return nil
 	}
 	r.finished = true
-	r.stream.ResourceDrop()
+	if r.stream != cm.ResourceNone {
+		r.stream.ResourceDrop()
+	}
 
 	future := types.IncomingBodyFinish(r.body)
 	defer future.ResourceDrop()

--- a/wasihttp/types.go
+++ b/wasihttp/types.go
@@ -190,7 +190,9 @@ func (w *bodyWriter) Flush() {
 	if w.finished {
 		return
 	}
-	w.stream.Flush()
+	if w.stream != cm.ResourceNone {
+		w.stream.Flush()
+	}
 }
 
 func (w *bodyWriter) finish() error {
@@ -198,8 +200,10 @@ func (w *bodyWriter) finish() error {
 		return nil
 	}
 	w.finished = true
-	w.stream.Flush()
-	w.stream.ResourceDrop()
+	if w.stream != cm.ResourceNone {
+		w.stream.Flush()
+		w.stream.ResourceDrop()
+	}
 
 	var trailers cm.Option[types.Trailers]
 	if w.trailer != nil {


### PR DESCRIPTION
- **examples/basic: fix lint issue**
- **wasihttp: fix issues with wasi-http Transport and streams**
- **examples/basic: add documentation**
- **examples/proxy: add proxy example**
- **wasihttp: do not drop a stream resource == 0**
- **wasihttp, examples/proxy: override net/http.DefaultTransport and DefaultClient**
- **examples/basic, wasihttp: let the server implementation handle incomplete responses**
