### PR TITLE
fix roundtrip go test workflow action

### DIFF
--- a/examples/roundtrip/roundtrip.go
+++ b/examples/roundtrip/roundtrip.go
@@ -60,7 +60,7 @@ func main() {
 		panic(err.Error())
 	}
 
-	req, err = http.NewRequest("PUT", "http://postman-echo.com/put", bytes.NewReader([]byte("{\"baz\": \"blah\"}")))
+	req, err = http.NewRequest("PUT", "https://postman-echo.com/put", bytes.NewReader([]byte("{\"baz\": \"blah\"}")))
 	if err != nil {
 		panic(err.Error())
 	}

--- a/scripts/test-roundtrip.sh
+++ b/scripts/test-roundtrip.sh
@@ -15,14 +15,14 @@ if ! echo "$output" | grep -q "Status: 200" || ! echo "$output" | grep -q "https
 fi
 
 # Verify POST request worked
-if ! echo "$output" | grep -q '"foo": "bar"'; then
+if ! echo "$output" | grep -q '"foo":"bar"'; then
 	echo "ERROR: POST request verification failed"
 	echo "$output"
 	exit 1
 fi
 
 # Verify PUT request worked
-if ! echo "$output" | grep -q '"baz": "blah"'; then
+if ! echo "$output" | grep -q '"baz":"blah"'; then
 	echo "ERROR: PUT request verification failed"
 	echo "$output"
 	exit 1


### PR DESCRIPTION
I noticed that after large merge, the Go Test had failed. Upon investigation I found two things:

1. It seems like postman-echo returns data without spaces in json. e.g. it returns `"foo":"bar"` instead of `"foo": "bar"` in json data returned back.

<details>

<summary>curl request</summary>
```
 curl -vXPOST "https://postman-echo.com/post" -d '{"foo": "bar"}' -H'Content-Type: application/json'
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host postman-echo.com:443 was resolved.
* IPv6: (none)
* IPv4: 3.215.218.87, 3.215.44.249, 54.243.141.228
*   Trying 3.215.218.87:443...
* Connected to postman-echo.com (3.215.218.87) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=postman-echo.com
*  start date: May 10 20:32:46 2025 GMT
*  expire date: Aug  8 20:32:45 2025 GMT
*  subjectAltName: host "postman-echo.com" matched cert's "postman-echo.com"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://postman-echo.com/post
* [HTTP/2] [1] [:method: POST]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: postman-echo.com]
* [HTTP/2] [1] [:path: /post]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [content-type: application/json]
* [HTTP/2] [1] [content-length: 14]
> POST /post HTTP/2
> Host: postman-echo.com
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 14
> 
* upload completely sent off: 14 bytes
< HTTP/2 200 
< content-type: application/json; charset=utf-8
< content-length: 275
< etag: W/"113-tptPlCOFBA6HXQ+Ok4PRlkOhJjc"
< vary: Accept-Encoding
< set-cookie: sails.sid=s%3AWQXsL817kUuNHdtS0pwgAIl3APQXON85.jQeAicCcMjhqfgt7XuXinkY9snWWXXruS%2BUbCG777EA; Path=/; HttpOnly
< date: Fri, 20 Jun 2025 01:43:37 GMT
< x-envoy-upstream-service-time: 5
< server: istio-envoy
< 
* Connection #0 to host postman-echo.com left intact
{"args":{},"data":{"foo":"bar"},"files":{},"form":{},"headers":{"host":"postman-echo.com","user-agent":"curl/8.7.1","accept":"*/*","content-type":"application/json","content-length":"14","x-forwarded-proto":"https"},"json":{"foo":"bar"},"url":"https://postman-echo.com/post"}
```

</details>

2. The put request is using `http` url instead of https, so it is returning `301` status code with redirect to `https` url. 

<details>

<summary>curl request</summary>
curl -vXPUT "http://postman-echo.com/put" -d '{"foo":"bar"}'
* Host postman-echo.com:80 was resolved.
* IPv6: (none)
* IPv4: 3.215.218.87, 54.243.141.228, 3.215.44.249
*   Trying 3.215.218.87:80...
* Connected to postman-echo.com (3.215.218.87) port 80
> PUT /put HTTP/1.1
> Host: postman-echo.com
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Length: 13
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 13 bytes
< HTTP/1.1 301 Moved Permanently
< location: https://postman-echo.com/put
< date: Fri, 20 Jun 2025 01:47:19 GMT
< server: istio-envoy
< connection: close
< content-length: 0
< 
* Closing connection
</details>

Also this seems like a recent rollout as these tests have worked in past and the tests on last merge were successful.